### PR TITLE
seo: make every page discoverable, and fix the two h1s that were not

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+# GitHub reads this to offer a "Cite this repository" button, and indexers that
+# understand CFF pick the project up as a citable software artifact.
+cff-version: 1.2.0
+title: >-
+  ocm-mcp-server: guardrailed AgentOps for multi-cluster
+  Kubernetes fleets
+message: If you use this software, please cite it as below.
+type: software
+authors:
+  - given-names: Sandeep
+    family-names: Bazar
+    website: https://www.linkedin.com/in/sandeepbazar/
+repository-code: https://github.com/ocm-mcp-server/ocm-mcp-server
+url: https://ocm-mcp-server.github.io/
+abstract: >-
+  An MCP (Model Context Protocol) server that lets AI agents operate a
+  multi-cluster Kubernetes fleet through an Open Cluster Management hub. The
+  agent never holds a kubeconfig. Four independent layers stand between the
+  model and the clusters: static guardrails, Kyverno policy admission in
+  dry-run, a human Ed25519 approval token bound to the exact content hash,
+  and least-privilege RBAC. Every tool call is recorded in a hash-chained,
+  tamper-evident audit log, and the project ships an evaluation harness of
+  scripted incident scenarios that scores diagnosis, recovery and safety
+  against a real fleet.
+keywords:
+  - model context protocol
+  - mcp server
+  - kubernetes
+  - open cluster management
+  - multi-cluster
+  - agentops
+  - ai agents
+  - llm safety
+  - guardrails
+  - kyverno
+  - policy as code
+  - site reliability engineering
+  - platform engineering
+  - cloud native
+license: Apache-2.0
+version: 0.6.0
+date-released: "2026-08-30"

--- a/hack/build_site.py
+++ b/hack/build_site.py
@@ -25,10 +25,13 @@ from __future__ import annotations
 import argparse
 import hashlib
 import html
+import json
 import re
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -287,7 +290,14 @@ def first_paragraph(tokens: list[Token]) -> str:
 
 
 def strip_leading_h1(body: str) -> tuple[str, str]:
-    m = re.match(r"\s*<h1[^>]*>(.*?)</h1>", body, re.DOTALL)
+    """Pull the page's own <h1> out of the body; the shell renders the title itself.
+
+    Leading HTML comments have to be skipped, not just whitespace. Three pages carry an
+    SPDX header above their heading, and an anchored match that did not allow for it left
+    their source h1 in place while the shell added a second one - two <h1> elements on a
+    page, which is a real signal to both a screen reader and a crawler.
+    """
+    m = re.match(r"(?:\s*<!--.*?-->)*\s*<h1[^>]*>(.*?)</h1>", body, re.DOTALL)
     if not m:
         return "", body
     title = re.sub(r"<[^>]+>", "", m.group(1)).strip()
@@ -527,6 +537,172 @@ def cards(pages: list[Page], section: str, base: str, limit: int) -> str:
     return "".join(out)
 
 
+# --------------------------------------------------------------------- discoverability
+
+REPO_URL = "https://github.com/ocm-mcp-server/ocm-mcp-server"
+
+
+def jsonld(obj: dict[str, Any]) -> str:
+    """One <script type="application/ld+json"> block.
+
+    Search engines read the page's prose either way; this is the same facts in the shape
+    they parse without guessing - which is what makes a result eligible to be rendered as
+    something richer than a blue link.
+    """
+    return (
+        '<script type="application/ld+json">'
+        + json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
+        + "</script>"
+    )
+
+
+def home_jsonld() -> str:
+    """The project itself: an application you can install, and the source it is built from."""
+    return jsonld(
+        {
+            "@context": "https://schema.org",
+            "@graph": [
+                {
+                    "@type": "SoftwareApplication",
+                    "@id": f"{SITE_URL}#software",
+                    "name": "ocm-mcp-server",
+                    "applicationCategory": "DeveloperApplication",
+                    "applicationSubCategory": "Model Context Protocol server",
+                    "operatingSystem": "Linux, macOS",
+                    "url": SITE_URL,
+                    "downloadUrl": "https://pypi.org/project/ocm-mcp-server/",
+                    "codeRepository": REPO_URL,
+                    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+                    "description": (
+                        "An MCP server that lets AI agents operate a multi-cluster Kubernetes "
+                        "fleet through an Open Cluster Management hub, with policy, human "
+                        "approval and audit between the model and your clusters."
+                    ),
+                    "keywords": (
+                        "MCP server, Model Context Protocol, Kubernetes, Open Cluster "
+                        "Management, OCM, multi-cluster, AgentOps, AI agent, Kyverno, "
+                        "guardrails, SRE, platform engineering"
+                    ),
+                    "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
+                    "author": {"@type": "Person", "name": "Sandeep Bazar"},
+                },
+                {
+                    "@type": "SoftwareSourceCode",
+                    "@id": f"{SITE_URL}#source",
+                    "name": "ocm-mcp-server",
+                    "codeRepository": REPO_URL,
+                    "programmingLanguage": "Python",
+                    "runtimePlatform": "Python 3.11+",
+                    "license": "https://www.apache.org/licenses/LICENSE-2.0",
+                    "about": {"@id": f"{SITE_URL}#software"},
+                },
+            ],
+        }
+    )
+
+
+def page_jsonld(page: Page, description: str) -> str:
+    """A documentation page, and the trail that leads to it."""
+    url = f"{SITE_URL}{page.url}"
+    crumbs = [
+        {"@type": "ListItem", "position": 1, "name": "ocm-mcp-server", "item": SITE_URL},
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "name": SECTION_LABEL[page.section],
+            "item": f"{SITE_URL}{page.section}/",
+        },
+        {"@type": "ListItem", "position": 3, "name": page.title, "item": url},
+    ]
+    graph: list[dict[str, Any]] = [
+        {
+            "@type": "TechArticle",
+            "headline": page.title,
+            "description": description,
+            "url": url,
+            "isPartOf": {"@id": f"{SITE_URL}#software"},
+            "author": {"@type": "Person", "name": "Sandeep Bazar"},
+            "license": "https://www.apache.org/licenses/LICENSE-2.0",
+        },
+        {"@type": "BreadcrumbList", "itemListElement": crumbs},
+    ]
+    faq = faq_entries(page)
+    if faq:
+        graph.append({"@type": "FAQPage", "url": url, "mainEntity": faq})
+    return jsonld({"@context": "https://schema.org", "@graph": graph})
+
+
+def faq_entries(page: Page) -> list[dict[str, Any]]:
+    """Question/answer pairs, for the one page that is actually a FAQ.
+
+    Read back out of the rendered body rather than the markdown, so the answer text is
+    exactly what a reader sees. A page whose h2s are not questions returns nothing.
+    """
+    if page.stem != "FAQ":
+        return []
+    out = []
+    for m in re.finditer(r"<h2[^>]*>(.*?)</h2>(.*?)(?=<h2|\Z)", page.body, re.DOTALL):
+        question = re.sub(r"<[^>]+>", "", m.group(1)).replace("#", "").strip()
+        answer = re.sub(r"<[^>]+>", " ", m.group(2))
+        answer = html.unescape(re.sub(r"\s+", " ", answer)).strip()
+        if question.endswith("?") and answer:
+            out.append(
+                {
+                    "@type": "Question",
+                    "name": html.unescape(question),
+                    "acceptedAnswer": {"@type": "Answer", "text": answer[:1200]},
+                }
+            )
+    return out
+
+
+def last_modified(src: Path) -> str:
+    """The source file's last commit date, so <lastmod> is a fact rather than build noise.
+
+    A sitemap that claims every page changed on every deploy teaches a crawler to ignore
+    the field; falling back to today only when git cannot answer keeps it honest.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "log", "-1", "--format=%cs", "--", str(src)],
+            capture_output=True, text=True, cwd=REPO, check=True, timeout=20,
+        ).stdout.strip()
+        if out:
+            return out
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return datetime.now(UTC).date().isoformat()
+
+
+def write_sitemap(pages: list[Page]) -> None:
+    """Every canonical URL the site serves, with a real last-modified date.
+
+    The home page is the entry point and is weighted accordingly; /results/ is a redirect
+    stub and is deliberately absent, because listing a URL that immediately sends the
+    crawler elsewhere spends crawl budget to say nothing.
+    """
+    rows = [(SITE_URL, last_modified(REPO / "web" / "templates" / "home.html"), "1.0")]
+    rows += [(f"{SITE_URL}{p.url}", last_modified(p.src), "0.8") for p in pages]
+    body = "".join(
+        f"<url><loc>{loc}</loc><lastmod>{mod}</lastmod><priority>{pri}</priority></url>"
+        for loc, mod, pri in rows
+    )
+    (OUT / "sitemap.xml").write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        f"{body}</urlset>",
+        encoding="utf-8",
+    )
+    (OUT / "robots.txt").write_text(
+        "# Everything here is public documentation; crawl all of it.\n"
+        "User-agent: *\n"
+        "Allow: /\n"
+        "\n"
+        f"Sitemap: {SITE_URL}sitemap.xml\n",
+        encoding="utf-8",
+    )
+
+
 def build(base: str) -> int:
     pages, orphans = discover()
     if orphans:
@@ -565,7 +741,7 @@ def build(base: str) -> int:
     page_tpl = (WEB / "templates" / "page.html").read_text()
     home_tpl = (WEB / "templates" / "home.html").read_text()
 
-    def shell(body: str, title: str, description: str, url: str) -> str:
+    def shell(body: str, title: str, description: str, url: str, structured: str = "") -> str:
         section = url.split("/")[0] if "/" in url else ""
         return fill(
             base_tpl,
@@ -580,6 +756,7 @@ def build(base: str) -> int:
                 "canonical": SITE_URL + url,
                 "body": body,
                 "megamenu": megamenu(pages, base, section),
+                "jsonld": structured,
             },
         )
 
@@ -598,7 +775,13 @@ def build(base: str) -> int:
         out = OUT / page.url / "index.html"
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(
-            shell(body, f"{page.title} · ocm-mcp-server", page.description, page.url),
+            shell(
+                body,
+                f"{page.title} · ocm-mcp-server",
+                page.description,
+                page.url,
+                page_jsonld(page, page.description),
+            ),
             encoding="utf-8",
         )
 
@@ -626,6 +809,7 @@ def build(base: str) -> int:
             "through an Open Cluster Management hub, with policy, approval and audit "
             "between the model and your clusters.",
             "",
+            home_jsonld(),
         ),
         encoding="utf-8",
     )
@@ -641,6 +825,34 @@ def build(base: str) -> int:
         encoding="utf-8",
     )
 
+    # A 404 in the site's own shell rather than GitHub's bare default. It is marked
+    # noindex: a soft-404 that a crawler indexes competes with the real pages for the
+    # same queries, which is the opposite of what a 404 is for.
+    (OUT / "404.html").write_text(
+        shell(
+            '<main id="main"><section class="shell sec">'
+            '<div class="sec__head"><h1>That page moved, or never existed</h1>'
+            "<p>The documentation is organized in three passes: why it exists, how to run "
+            "it, and the evidence it works. Any of them is a good place to pick the "
+            "thread back up.</p></div>"
+            '<div class="hero__cta">'
+            f'<a class="btn btn--primary" href="{base}journey/why-this-exists/">Start here</a>'
+            f'<a class="btn btn--ghost" href="{base}reference/architecture/">Run it</a>'
+            f'<a class="btn btn--ghost" href="{base}results/test-results/">See the proof</a>'
+            "</div></section></main>",
+            "Page not found · ocm-mcp-server",
+            "That page moved or never existed. Start from the journey, the reference, or "
+            "the published results.",
+            "404.html",
+        ).replace(
+            '<meta name="robots" content="index, follow',
+            '<meta name="robots" content="noindex, follow',
+        ),
+        encoding="utf-8",
+    )
+
+    write_sitemap(pages)
+
     shutil.copytree(WEB / "static", OUT / "static")
     shutil.copytree(WEB / "vendor", OUT / "vendor")
     shutil.copytree(DOCS / "assets", OUT / "assets")
@@ -650,7 +862,10 @@ def build(base: str) -> int:
     # without bound, and git keeps every version of a binary forever.
     (OUT / ".nojekyll").write_text("")
 
-    print(f"built {len(pages) + 1} pages into {OUT.relative_to(REPO)}/ (base={base})")
+    print(
+        f"built {len(pages) + 1} pages into {OUT.relative_to(REPO)}/ "
+        f"(base={base}), with sitemap.xml and robots.txt"
+    )
     return 0
 
 

--- a/hack/build_site.py
+++ b/hack/build_site.py
@@ -297,11 +297,26 @@ def strip_leading_h1(body: str) -> tuple[str, str]:
     their source h1 in place while the shell added a second one - two <h1> elements on a
     page, which is a real signal to both a screen reader and a crawler.
     """
-    m = re.match(r"(?:\s*<!--.*?-->)*\s*<h1[^>]*>(.*?)</h1>", body, re.DOTALL)
+    # The skipping is a loop rather than part of the pattern on purpose. Expressing it as
+    # `(?:\s*<!--.*?-->)*\s*` puts a star around a `\s*`, and the two ways of splitting a
+    # run of whitespace between the iterations and the tail make the match backtrack
+    # polynomially on any body that is whitespace all the way down. This is linear.
+    i, n = 0, len(body)
+    while i < n:
+        if body[i].isspace():
+            i += 1
+        elif body.startswith("<!--", i):
+            end = body.find("-->", i + 4)
+            if end < 0:
+                break
+            i = end + 3
+        else:
+            break
+    m = re.match(r"<h1[^>]*>(.*?)</h1>", body[i:], re.DOTALL)
     if not m:
         return "", body
     title = re.sub(r"<[^>]+>", "", m.group(1)).strip()
-    return title, body[m.end() :]
+    return title, body[i + m.end() :]
 
 
 def render_pages(pages: list[Page], base: str) -> list[str]:
@@ -641,9 +656,11 @@ def faq_entries(page: Page) -> list[dict[str, Any]]:
     if page.stem != "FAQ":
         return []
     out = []
-    for m in re.finditer(r"<h2[^>]*>(.*?)</h2>(.*?)(?=<h2|\Z)", page.body, re.DOTALL):
-        question = re.sub(r"<[^>]+>", "", m.group(1)).replace("#", "").strip()
-        answer = re.sub(r"<[^>]+>", " ", m.group(2))
+    for chunk in page.body.split("<h2")[1:]:
+        head, _, rest = chunk.partition("</h2>")
+        _, _, head = head.partition(">")
+        question = re.sub(r"<[^>]+>", "", head).replace("#", "").strip()
+        answer = re.sub(r"<[^>]+>", " ", rest)
         answer = html.unescape(re.sub(r"\s+", " ", answer)).strip()
         if question.endswith("?") and answer:
             out.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,12 @@ readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
 authors = [{ name = "Sandeep Bazar" }]
-keywords = ["mcp", "kubernetes", "open-cluster-management", "ai-agents", "multicluster"]
+keywords = [
+    "mcp", "mcp-server", "model-context-protocol", "kubernetes", "k8s",
+    "open-cluster-management", "ocm", "multicluster", "multi-cluster", "fleet",
+    "ai-agents", "agentops", "llm", "llm-safety", "guardrails", "kyverno",
+    "policy-as-code", "sre", "platform-engineering", "cloud-native", "audit",
+]
 dependencies = [
     # Upper bounds are deliberate: MCP v2 is a major rewrite and the Kubernetes client
     # bumps its major on each K8s minor, so we cap to a tested range and widen on purpose.

--- a/web/static/site.css
+++ b/web/static/site.css
@@ -1452,3 +1452,15 @@ figure { margin: 1.8em 0; }
 .art img.art--light{display:none}
 [data-theme="light"] .art img.art--dark{display:none}
 [data-theme="light"] .art img.art--light{display:block}
+
+/* The star call to action. Both cuts ship; the stylesheet picks the one that matches
+   the theme the reader chose, the same way the animated panels do. */
+.starcta{display:flex;align-items:center;justify-content:center;gap:12px;margin:18px 0 0}
+.starcta__txt{font-weight:640;font-size:15px;color:var(--text)}
+.starcta__btn{display:inline-flex;border-radius:9px;line-height:0;
+  transition:transform .18s var(--ease),filter .18s var(--ease)}
+.starcta__btn:hover{transform:translateY(-1px);filter:brightness(1.08)}
+.starcta__btn img{display:block;width:132px;height:34px}
+.starcta__btn img.art--light{display:none}
+[data-theme="light"] .starcta__btn img.art--dark{display:none}
+[data-theme="light"] .starcta__btn img.art--light{display:block}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -24,6 +24,11 @@
 <meta name="twitter:description" content="{{description}}">
 <meta name="twitter:image" content="{{og_image}}">
 <link rel="canonical" href="{{canonical}}">
+<!-- Let the image-rich results actually show the art: without this a crawler
+     may only ever render a thumbnail, and every panel here is the argument. -->
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+<meta name="author" content="Sandeep Bazar">
+<link rel="sitemap" type="application/xml" href="{{base}}sitemap.xml">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#128737;</text></svg>">
 <link rel="stylesheet" href="{{css_href}}">
 <script>
@@ -54,6 +59,7 @@
     }, 2000);
   })();
 </script>
+{{jsonld}}
 </head>
 <body>
 <a class="skip" href="#main">Skip to content</a>

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -15,6 +15,18 @@
     <a class="btn btn--ghost" href="{{base}}reference/deployment/">Get started</a>
   </div>
 
+  <!-- The same star call to action the README carries, so the ask is in both places a
+       reader might land. The cursor presses and the star fills off one clock, which is
+       what makes it read as cause and effect rather than as two loops. -->
+  <p class="starcta" data-reveal style="--d:230ms">
+    <span class="starcta__txt">Star us&nbsp;❤️&nbsp;→</span>
+    <a class="starcta__btn" href="https://github.com/ocm-mcp-server/ocm-mcp-server"
+       target="_blank" rel="noopener" aria-label="Star ocm-mcp-server on GitHub">
+      <img class="art--dark" src="{{base}}assets/art/star-dark.svg" alt="" aria-hidden="true" width="132" height="34">
+      <img class="art--light" src="{{base}}assets/art/star-light.svg" alt="" aria-hidden="true" width="132" height="34">
+    </a>
+  </p>
+
   <div class="hero__art" data-reveal style="--d:260ms">
     <img class="hero__art-dark" src="{{base}}assets/art/hero-dark.svg" alt="An agent's tool calls pass through a guardrailed control plane where reads are free, consequential writes need a human signature, and everything is recorded." width="880" loading="eager">
     <img class="hero__art-light" src="{{base}}assets/art/hero-light.svg" alt="" aria-hidden="true" width="880" loading="lazy">


### PR DESCRIPTION
## What

Technical SEO for the docs site, plus two repo-level discoverability additions.

- **`sitemap.xml`** — generated from the page list, `<lastmod>` taken from each source file's last commit rather than the build clock. The `/results/` redirect stub is deliberately excluded.
- **`robots.txt`** — allows everything, names the sitemap.
- **JSON-LD on all 28 pages** — home page as `SoftwareApplication` + `SoftwareSourceCode`; every doc page as `TechArticle` + `BreadcrumbList`; the FAQ additionally emits a real `FAQPage` built from its own rendered Q&A pairs.
- **Custom 404** in the site shell, marked `noindex`.
- **`max-image-preview:large`**, so the animated panels are eligible for image results.
- **`CITATION.cff`** — GitHub shows a "Cite this repository" button; CFF-aware indexers see a citable artifact.
- **PyPI keywords** widened from 5 to 21 terms.
- **Animated star CTA** added to the site hero, in both theme cuts.

## Why

The site already had 29 unique titles, 29 unique descriptions, canonical links and social cards. What it had no way of doing was telling a crawler its shape: no sitemap, no robots.txt, no structured data. A 28-page site discovered link-by-link is a site whose deeper pages largely are not.

The `h1` fix came out of auditing rather than the plan. `strip_leading_h1` matched the heading only when it was the first thing in the rendered body, so the three pages carrying an SPDX comment above their title kept their own `h1` **and** received a second one from the shell. Two `h1` elements is a real signal to a screen reader and a crawler alike, and it was silently true on `reference/tools`, `reference/security-self-assessment` and `reference/cncf-sandbox-readiness`.

## How was it verified

- [x] `make lint` clean (`ruff check hack/build_site.py`)
- [x] `pytest tests/test_build_site.py` — 17 passed
- [x] All 28 JSON-LD blocks parsed as valid JSON; FAQ page confirmed to emit `FAQPage` with 8 real question/answer pairs
- [x] Sitemap contains 28 `<loc>` entries with per-file `lastmod` dates
- [x] The three previously-doubled pages now render exactly one `h1`
- [x] Site built and served locally, checked in both themes
- [ ] `make test` not run here — no container runtime in this environment; this change touches no server code

## A CodeQL finding this PR introduced, and fixed

The first commit's anchored matcher, `(?:\s*<!--.*?-->)*\s*<h1...`, put a star around a group beginning with `\s*` and then followed the group with another `\s*`. That gives the engine two ways to split every run of whitespace between them, so a body that is whitespace all the way down and never reaches a heading backtracks polynomially. CodeQL flagged it as a high-severity alert and was right to.

The second commit replaces the preamble-skipping with a single linear loop and splits the FAQ extractor on the heading tag rather than a lazy-run-plus-lookahead pattern. Behaviour is unchanged on all four preamble cases (comment, none, several, unterminated), and a 40,000-space body now parses in 3 ms.

## Notes for the reviewer

Two things this does **not** do, deliberately:

1. **No ranking is promised.** These changes remove technical barriers and make pages eligible for richer results. Position depends on external authority and competition, which no repository change controls.
2. **Repo topics are still unset** and cannot be set from here — no topics API is exposed to this session. That is the single highest-value remaining item, and it is a one-minute manual step in repo settings.