### PR TITLE
harden: let a deployment refuse to start when layer 3 cannot hold

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ ready-to-paste values at the end).
 | `OCM_MCP_MAX_PROPOSAL_BYTES` | no | Reject a proposal larger than this many bytes. Default `262144` (256 KiB). |
 | `OCM_MCP_MAX_HPA_REPLICAS` | no | Reject a HorizontalPodAutoscaler whose `maxReplicas` exceeds this. Default `100`. |
 | `OCM_MCP_READ_ONLY` | no | Set to `1`/`true` for a strictly-inspection deployment: every propose/apply tool refuses, a coarse backstop under the token gate. Default off. |
+| `OCM_MCP_STRICT` | no | Set to `1`/`true` to make the deployment preconditions layer&nbsp;3 rests on a **startup failure** rather than a stderr warning: a signer private key readable next to the server, or `OCM_MCP_ISSUER`/`OCM_MCP_AUDIENCE` left at their defaults. Recommended in production. Default off, so a laptop bootstrap still works with one shared home. |
 | `OCM_MCP_CLIENT_TTL` | no | Seconds before the cached Kubernetes API client is rebuilt, so rotated/refreshed credentials are picked up. Default `600`. |
 | `OCM_MCP_FANOUT_WORKERS` | no | Concurrent spoke scans during `get_fleet_health`. Default `8` (floor `1`). |
 | `OCM_MCP_SPOKE_TIMEOUT` | no | Read timeout (seconds) for spoke health/event/log calls, so one large cluster cannot hang a tool. Default `30`. |

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -29,7 +29,12 @@
    separate OS account or device via `OCM_MCP_SIGNER_KEY`. Co-located under one
    `OCM_MCP_HOME`, signer isolation is a filesystem convention, not an enforced
    boundary; treat off-box signing (or a chat-ops/ticket signer) as required for
-   that guarantee. An apply token cannot authorize a rollback; rollback needs its
+   that guarantee. Set **`OCM_MCP_STRICT=1`** and the convention becomes a
+   precondition: the server refuses to start while the private key is readable
+   beside it, or while `OCM_MCP_ISSUER`/`OCM_MCP_AUDIENCE` are left at their
+   defaults. Serving tools that look gated and are not is worse than not serving
+   them, and the warning these replace went to a stderr stream that an MCP client
+   usually swallows. An apply token cannot authorize a rollback; rollback needs its
    own proposal and token.
 4. **RBAC** (`deploy/rbac.yaml`) - the server's own identity can read the OCM API
    and create/delete ManifestWorks and manage add-ons. RBAC cannot scope this to

--- a/docs/security-self-assessment.md
+++ b/docs/security-self-assessment.md
@@ -171,7 +171,7 @@ documented threat model.
 
 - **Development pipeline**: contributions arrive via pull request. CI runs linting and
   format checks (ruff), static typing (mypy), the unit test suite with a coverage gate
-  (431 tests, 100% branch coverage, no cluster required), the offline Kyverno policy tests
+  (436 tests, 100% branch coverage, no cluster required), the offline Kyverno policy tests
   (42 cases, including a
   requester-identity bypass test), a dependency review, and a secret scan (gitleaks). A
   CodeQL workflow scans the code.

--- a/src/ocm_mcp_server/cli.py
+++ b/src/ocm_mcp_server/cli.py
@@ -146,6 +146,14 @@ def cmd_doctor(_args: argparse.Namespace) -> int:
     ctx = SETTINGS.hub_context or "(current kubeconfig context)"
     print(f"ocm-mcp doctor - live read-path smoke test\nhub context: {ctx}\n")
 
+    # Before the hub is even contacted: whether the approval gate is a gate here. This
+    # needs no cluster, and "can this deployment keep its promises" is exactly the
+    # question someone is asking when they run doctor before wiring up an agent.
+    from .server import deployment_warnings
+
+    for problem in deployment_warnings():
+        print(f"  WARN  deployment: {problem}\n")
+
     counts = {"OK": 0, "EMPTY": 0, "SKIP": 0, "FAIL": 0}
 
     def run(label: str, fn) -> object | None:

--- a/src/ocm_mcp_server/config.py
+++ b/src/ocm_mcp_server/config.py
@@ -255,6 +255,14 @@ class Settings:
             os.environ.get("OCM_MCP_READ_ONLY", "").strip().lower() in ("1", "true", "yes", "on")
         )
     )
+    # When truthy (OCM_MCP_STRICT=1/true/yes), the deployment preconditions that layer 3
+    # actually rests on stop being advice and become a refusal to start. Off by default so
+    # `make bootstrap` on a laptop still works with the CLI and server sharing one home.
+    strict: bool = field(
+        default_factory=lambda: (
+            os.environ.get("OCM_MCP_STRICT", "").strip().lower() in ("1", "true", "yes", "on")
+        )
+    )
     # When truthy (OCM_MCP_AUDIT_ECHO=1), each audit line is also written to STDERR as JSON,
     # so a container log collector can forward the audit stream to a SIEM/object store.
     # (stdout is reserved for the MCP protocol, so the echo goes to stderr.)

--- a/src/ocm_mcp_server/server.py
+++ b/src/ocm_mcp_server/server.py
@@ -1101,22 +1101,49 @@ _DEFAULT_ISSUER = "ocm-mcp"
 _DEFAULT_AUDIENCE = "ocm-mcp-server"
 
 
-def main() -> None:
+def deployment_warnings() -> list[str]:
+    """The deployment preconditions layer 3 actually rests on, and whether they hold.
+
+    Both of these were already reported at startup, and both went to stderr. An MCP server
+    is launched over stdio by an agent client, which is exactly the context where stderr is
+    swallowed into a log nobody opens - so the two conditions that decide whether human
+    approval means anything were, in practice, announced to no one.
+
+    Returning them lets `main()` refuse to start under OCM_MCP_STRICT and lets `ocm-mcp
+    doctor` print the same list, rather than the two drifting apart.
+    """
+    problems = []
     if SETTINGS.approval_private_key_path.exists():
-        print(
-            "ocm-mcp-server: WARNING: the approval PRIVATE key is present in this "
-            "server's own state directory - a compromised server could mint its own "
-            "approval tokens. Move it off-box and set OCM_MCP_SIGNER_KEY.",
-            file=sys.stderr,
+        problems.append(
+            "the approval PRIVATE key is readable from this server's own state directory, "
+            "so a compromised server could mint its own approval tokens and layer 3 stops "
+            f"being a gate ({SETTINGS.approval_private_key_path}). Move it to a separate "
+            "host or OS account and point the CLI at it with OCM_MCP_SIGNER_KEY; the server "
+            "needs only the .pub verifier."
         )
     if SETTINGS.issuer == _DEFAULT_ISSUER and SETTINGS.audience == _DEFAULT_AUDIENCE:
+        problems.append(
+            "OCM_MCP_ISSUER and OCM_MCP_AUDIENCE are both at their defaults, so a token "
+            "minted for any other default deployment verifies here too. Content-hash "
+            "binding still limits the blast radius, but set deployment-specific values."
+        )
+    return problems
+
+
+def main() -> None:
+    problems = deployment_warnings()
+    if problems and SETTINGS.strict:
+        for problem in problems:
+            print(f"ocm-mcp-server: REFUSING TO START: {problem}", file=sys.stderr)
         print(
-            "ocm-mcp-server: NOTE: OCM_MCP_ISSUER/OCM_MCP_AUDIENCE are both left at "
-            "their defaults, so a token minted for another default deployment would "
-            "verify here too (content-hash binding still limits the blast radius, "
-            "but set deployment-specific values for defense-in-depth).",
+            "ocm-mcp-server: OCM_MCP_STRICT is set, and a deployment that cannot keep "
+            "these promises should fail loudly rather than serve tools that look gated "
+            "and are not. Unset OCM_MCP_STRICT to run anyway.",
             file=sys.stderr,
         )
+        raise SystemExit(2)
+    for problem in problems:
+        print(f"ocm-mcp-server: WARNING: {problem}", file=sys.stderr)
     port = os.environ.get("OCM_MCP_METRICS_PORT", "").strip()
     if port.isdigit():
         from . import metrics

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -5,7 +5,7 @@
 
 import pytest
 
-from ocm_mcp_server import approvals, guardrails
+from ocm_mcp_server import approvals, guardrails, server
 from ocm_mcp_server.config import SETTINGS
 
 MANIFEST = {
@@ -335,3 +335,66 @@ def test_token_ledger_appends_then_stays_bounded(tmp_home):
         with pytest.raises(approvals.ApprovalError, match="already been used"):
             approvals.verify_token(p, t, operation="apply", consume=True)
     assert len(SETTINGS.used_tokens_path.read_text().strip().splitlines()) == 5
+
+
+# --------------------------------------------------------- deployment preconditions
+
+
+def _no_problems(monkeypatch, tmp_home):
+    """A deployment whose layer-3 promises hold: signer off-box, ids deployment-specific."""
+    monkeypatch.setattr(SETTINGS, "issuer", "acme-hub")
+    monkeypatch.setattr(SETTINGS, "audience", "acme-ocm-mcp")
+    SETTINGS.approval_private_key_path.unlink(missing_ok=True)
+
+
+def test_deployment_warnings_clean_when_promises_hold(tmp_home, monkeypatch):
+    _no_problems(monkeypatch, tmp_home)
+    assert server.deployment_warnings() == []
+
+
+def test_deployment_warnings_flag_a_colocated_signer(tmp_home, monkeypatch):
+    _no_problems(monkeypatch, tmp_home)
+    SETTINGS.approval_private_key_path.write_text("00" * 32)
+    (problem,) = server.deployment_warnings()
+    assert "PRIVATE key" in problem
+
+
+def test_deployment_warnings_flag_default_issuer_and_audience(tmp_home, monkeypatch):
+    _no_problems(monkeypatch, tmp_home)
+    monkeypatch.setattr(SETTINGS, "issuer", server._DEFAULT_ISSUER)
+    monkeypatch.setattr(SETTINGS, "audience", server._DEFAULT_AUDIENCE)
+    (problem,) = server.deployment_warnings()
+    assert "OCM_MCP_ISSUER" in problem
+
+
+def test_strict_mode_refuses_to_start(tmp_home, monkeypatch, capsys):
+    """The whole point: under OCM_MCP_STRICT a broken promise stops the server.
+
+    Serving tools that look gated and are not is worse than not serving them, so this
+    fails loudly rather than warning into a stderr stream nobody reads.
+    """
+    _no_problems(monkeypatch, tmp_home)
+    SETTINGS.approval_private_key_path.write_text("00" * 32)
+    monkeypatch.setattr(SETTINGS, "strict", True)
+    ran = []
+    monkeypatch.setattr(server.mcp, "run", lambda *a, **k: ran.append(True))
+
+    with pytest.raises(SystemExit) as exc:
+        server.main()
+
+    assert exc.value.code == 2
+    assert ran == [], "the server must not start once it has refused"
+    assert "REFUSING TO START" in capsys.readouterr().err
+
+
+def test_without_strict_the_same_deployment_only_warns(tmp_home, monkeypatch, capsys):
+    _no_problems(monkeypatch, tmp_home)
+    SETTINGS.approval_private_key_path.write_text("00" * 32)
+    monkeypatch.setattr(SETTINGS, "strict", False)
+    ran = []
+    monkeypatch.setattr(server.mcp, "run", lambda *a, **k: ran.append(True))
+
+    server.main()
+
+    assert ran == [True], "default behaviour is unchanged: it warns and serves"
+    assert "WARNING" in capsys.readouterr().err

--- a/wiki/Guardrails-Deep-Dive.md
+++ b/wiki/Guardrails-Deep-Dive.md
@@ -68,6 +68,14 @@ and the server only the public key, so the server can verify a token but can nev
 mint one. Minted only by the `ocm-mcp` CLI on a trusted terminal. See
 [How It Works](How-It-Works) for the token mechanics.
 
+That "can never mint" holds only while the signing key is genuinely off the
+server. Co-located under one `OCM_MCP_HOME` it is a filesystem convention, so
+`OCM_MCP_STRICT=1` turns it into a precondition: the server refuses to start
+while the private key is readable beside it, or while the issuer and audience
+are left at their defaults. Both were already reported at startup, and both
+went to stderr - which an MCP client, launching the server over stdio, usually
+swallows into a log nobody opens.
+
 ## Layer 4: least-privilege RBAC
 
 The server's hub identity can read across the OCM API and create/delete

--- a/wiki/Implementation.md
+++ b/wiki/Implementation.md
@@ -153,7 +153,7 @@ back via `get_audit_trail` to write an accurate post-incident report.
 
 ## Tests
 
-- `tests/` unit tests (431; 100% statement and branch coverage): the full approval-token lifecycle (roundtrip,
+- `tests/` unit tests (436; 100% statement and branch coverage): the full approval-token lifecycle (roundtrip,
   wrong-proposal, content-change invalidation, expiry, tampering, malformed,
   public-key-only verification, operation binding, keypair rotation) for both
   ManifestWork and lifecycle-action proposals, every static guardrail case


### PR DESCRIPTION
## What

Adds `OCM_MCP_STRICT`. When set, the server refuses to start (exit `2`) if either deployment precondition that layer 3 rests on is broken:

1. the approval **private** key is readable from the server's own state directory, or
2. `OCM_MCP_ISSUER` and `OCM_MCP_AUDIENCE` are both still at their defaults.

Off by default. The two checks move into one `deployment_warnings()` function, which `ocm-mcp doctor` now prints too — before it contacts the hub, so the answer arrives even when the kubeconfig is wrong.

## Why

Both conditions were already checked at startup — and both were reported by printing to **stderr**. That is the one place the check cannot land: an MCP server is launched over stdio by an agent client, so its stderr goes into a client log nobody opens, or nowhere. The two conditions that decide whether human approval means anything were, in practice, announced to no one.

`docs/guardrails.md` was already honest that "signer isolation is a filesystem convention, not an enforced boundary". This makes it enforceable for anyone who wants it, without changing the default. Serving a tool surface that *looks* gated and is not is worse than refusing to serve it.

Deliberately opt-in: `make bootstrap` on a laptop runs the CLI and the server under one `OCM_MCP_HOME` — that is what the quickstart tells people to do, and breaking it to protect production would be the wrong trade.

## How was it verified

- [x] `make test` — 436 passed (5 new)
- [x] `make lint` — clean
- [x] `hack/docs_stats.py --check` — in sync (the new tests moved the quoted count 431 → 436; `--fix` updated both places that quote it)
- [x] Precondition detection exercised across all four corners: clean/dirty home × default/custom issuer
- [x] The test that matters asserts `mcp.run()` is **never reached** once the server has refused — a refusal that still served tools would be worse than no check at all
- [x] Default path unchanged: same deployment without the flag warns and serves
- [x] `ocm-mcp doctor` run against a co-located key with no kubeconfig: both warnings print ahead of the read-path table

## Notes for the reviewer

- Exit code `2` rather than `1`, to read as "misconfigured" rather than "crashed".
- The flag parses with the same truthy set as `OCM_MCP_READ_ONLY` (`1/true/yes/on`).
- Documented in the README env table, `docs/guardrails.md` (layer 3's isolation caveat) and `wiki/Guardrails-Deep-Dive.md`.
- No new dependency, no change to the token format, and no change to any tool's behaviour.