### PR TITLE
seo: give the publisher the history its sitemap dates depend on

### DIFF
--- a/.github/workflows/publish-root-site.yaml
+++ b/.github/workflows/publish-root-site.yaml
@@ -50,6 +50,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Full history: the sitemap dates each URL from its source file's last
+          # commit, and the default shallow clone has no commit to read, so every
+          # page would claim it changed on this deploy - which is exactly the
+          # signal that teaches a crawler to ignore <lastmod> altogether.
+          fetch-depth: 0
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/hack/build_site.py
+++ b/hack/build_site.py
@@ -704,6 +704,14 @@ def write_sitemap(pages: list[Page]) -> None:
         f"<url><loc>{loc}</loc><lastmod>{mod}</lastmod><priority>{pri}</priority></url>"
         for loc, mod, pri in rows
     )
+    if len(pages) > 1 and len({mod for _, mod, _ in rows}) == 1:
+        print(
+            "build_site: WARNING: every sitemap entry carries the same date, which is what "
+            "a shallow checkout produces - git can only see the one commit it fetched. A "
+            "sitemap that says every page changed on every deploy trains a crawler to "
+            "ignore <lastmod>; check out with fetch-depth: 0.",
+            file=sys.stderr,
+        )
     (OUT / "sitemap.xml").write_text(
         '<?xml version="1.0" encoding="UTF-8"?>'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'


### PR DESCRIPTION
## What

`fetch-depth: 0` on the site-publishing checkout, and a warning from the builder when every sitemap entry lands on the same date.

## Why — a bug #47 shipped

The sitemap dates each URL from its source file's last commit. `actions/checkout` defaults to depth 1, so in CI git has exactly one commit, reports every file as added in it, and every `<lastmod>` comes out as the build date.

The currently published sitemap says `2026-09-06` for **all 28 URLs**. Locally the same code produces a proper spread (2026-08-29 through 09-06), which is why it looked correct when I verified it — a developer's checkout has history, and CI's does not.

That is exactly the failure the feature was written to avoid. From the function's own docstring in #47: *"A sitemap that claims every page changed on every deploy teaches a crawler to ignore the field."* It did that in the only place that matters.

## Why the check is on the symptom, not the cause

My first attempt warned on `git rev-parse --is-shallow-repository`. That is the wrong question: this project's ordinary checkouts are grafted (this one has 70 commits) and date files perfectly well, so it would cry wolf on every normal build. A second attempt warned when `git log` returned nothing — which never happens, because a depth-1 clone does not fail, it confidently reports the one commit it has.

The condition that actually distinguishes the broken case is the symptom: every entry carrying an identical date.

## How was it verified

- [x] Reproduced against a real `git clone --depth 1` of this branch: warning fires, all dates identical
- [x] Same build on a normal checkout: silent, dates spread across four days
- [x] `pytest tests/test_build_site.py` — 17 passed
- [x] `ruff` clean

## Notes for the reviewer

`pages.yaml` needs no change — it only builds a redirect stub and never calls the site builder. `publish-root-site.yaml` is the only workflow that runs `hack/build_site.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ANUXBNtRRT8NAGXGF4Pdr)_